### PR TITLE
Confluent operator and Confluent Platform to GKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ I posted many articles about videos about this discussion. Get started with [How
 
 ### Kubernetes
 
+We have prepared a terraform script to deploy the complete environment in Google Kubernetes Engine (GKE). Follow the instructions to setup the cluster [here](infrastructure/terraform-gcp/README.md)
 todo
 
 ### HiveMQ

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -2,6 +2,6 @@
 
 Components (in order of deployment):
 - [terraform-gcp](terraform-gcp): A terraform script for setting up a basic Kubernetes Cluster on GKE and provisioning it with Tiller and the Prometheus operator.
-- TODO confluent operator and platform, this should be set up first
+- And confluent operator and platform, a small Confluent Cluster is setup, 1 Zookeeper, 1 Kafka Broker, 1 Schema Registry, 1 KSQL-Server, 1 Control Center
 - [hivemq](hivemq): Scripting for creating the HiveMQ operator on K8s and deploying a basic cluster with the Kafka extension installed as well as a monitoring dashboard for use with the Prometheus operator.
 - [test-generator](test-generator): Scripting for running the load generator which will simulate the car clients, publishing sensor data.

--- a/infrastructure/terraform-gcp/README.md
+++ b/infrastructure/terraform-gcp/README.md
@@ -6,6 +6,8 @@ Applying this terraform deployment will create a K8s cluster with the following 
 * Prometheus Operator & Prometheus
 * metrics-server for Kubernetes metrics in dashboard
 * K8s dashboard (use `gcloud config config-helper --format=json | jq -r ‘.credential.access_token’` for login)
+* Confluent Operator
+* Confluent Cluster running in one Zone with only one replica of each component
 
 It will also set your kubectl context to the gcp cluster automatically. (To undo this, see `kubectl config get-contexts` and switch to your preferred context)
 
@@ -24,11 +26,16 @@ Make sure to have updated versions, e.g. an older version of helm did not work.
 
 # Quick Start
 
-1. Ensure account.json is in this folder. You will have to [create a service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) on GCP first.
+1. Ensure account.json is in this folder. You will have to [create a service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) on GCP first. Choose the right roles and enable google API. If something is missing terraform let you know.
 
 2. Choose a GCP project or create a new one on your cloud console. Terraform will prompt you to specify your project name when applying.
 
-3.
+3. Before starting terraform: update the file [variables.tf](variables.tf). Here you will find entries which have to fit with your environment.
+During the terraform deployment the Confluent Operator (Version v0.65.1) will be downloaded ([The logic is in setup.sh](setup.sh)). If there is newer version please update the link in setup.sh.
+We use Google Cloud Confluent Operator template [gcp.yaml](gcp.yaml) for installing the Confluent Platform into GKE created K8s cluster. The template is copied into the new downloaded Confluent Operator Helm-Chart-Producer directory. Please change this file for your setup. We use Cloud Region=europe-west1 and Zone=europe-west1-b and replicas=1.
+The script [setup.sh](setup.sh) will create all components into GKE cluster.
+
+4. Create the environment in Google Cloud
 ```bash
 terraform init
 terraform apply
@@ -45,6 +52,9 @@ terraform apply
 * Forward local port to Grafana service: `kubectl port-forward service/prom-grafana 3000:service`
 * Go to [localhost:3000](http://localhost:3000) (login: admin, prom-operator)
 * Dashboards will be deployed automatically (if they are not visible, bounce the deployment by deleting the current Grafana pod. It will reload the ConfigMaps after it restarts.)
+
+# Confluent Platform
+Follow the examples of how to use and play with Confluent Platform on GCP K8s on [Confluent docs](https://docs.confluent.io/current/installation/operator/co-deployment.html)
 
 # Destroy Infrastructure
 

--- a/infrastructure/terraform-gcp/gcp.yaml
+++ b/infrastructure/terraform-gcp/gcp.yaml
@@ -1,0 +1,203 @@
+## Overriding values for Chart's values.yaml
+## Example values to run Confluent Operator in GCP
+global:
+  provider:
+    name: gcp
+    region: europe-west1
+    kubernetes:
+       deployment:
+         ## If kubernetes is deployed in multi zone mode then specify availability-zones as appropriate
+         ## If kubernetes is deployed in single availability zone then specify appropriate values
+         zones:
+          - europe-west1-b
+    storage:
+      ## https://kubernetes.io/docs/concepts/storage/storage-classes/#gce
+      ##
+      provisioner: kubernetes.io/gce-pd
+      ## Use Retain if you want to persist data after CP cluster has been uninstalled
+      reclaimPolicy: Delete
+      parameters:
+        type: pd-ssd
+    ## Docker registry endpoint where Confluent Images are available.
+    ##
+    registry:
+      fqdn: docker.io
+      credential:
+        required: false
+  sasl:
+    plain:
+      username: test
+      password: test123
+
+## Zookeeper cluster
+##
+zookeeper:
+  name: zookeeper
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
+## Kafka Cluster
+##
+kafka:
+  name: kafka
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+  loadBalancer:
+    enabled: false
+    domain: ""
+  tls:
+    enabled: false
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  metricReporter:
+    enabled: false
+
+## Connect Cluster
+##
+connect:
+  name: connectors
+  replicas: 1
+  tls:
+    enabled: false
+    ## "" for none, "tls" for mutual auth
+    authentication:
+      type: ""
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  loadBalancer:
+    enabled: false
+    domain: ""
+  dependencies:
+    kafka:
+      bootstrapEndpoint: kafka:9071
+      brokerCount: 1
+    schemaRegistry:
+      enabled: true
+      url: http://schemaregistry:8081
+## Replicator Connect Cluster
+##
+replicator:
+  name: replicator
+  replicas: 1
+  tls:
+    enabled: false
+    authentication:
+      type: ""
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  loadBalancer:
+    enabled: false
+    domain: ""
+  dependencies:
+    kafka:
+      brokerCount: 1
+      bootstrapEndpoint: kafka:9071
+##
+## Schema Registry
+##
+schemaregistry:
+  name: schemaregistry
+  replicas: 1
+  tls:
+    enabled: false
+    authentication:
+      type: ""
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  loadBalancer:
+    enabled: false
+    domain: ""
+  dependencies:
+    kafka:
+      brokerCount: 1
+      bootstrapEndpoint: kafka:9071
+
+##
+## KSQL
+##
+ksql:
+  name: ksql
+  replicas: 1
+  tls:
+    enabled: false
+    authentication:
+      type: ""
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  loadBalancer:
+    enabled: false
+    domain: ""
+  dependencies:
+    kafka:
+      brokerCount: 1
+      bootstrapEndpoint: kafka:9071
+      brokerEndpoints: kafka-0.kafka:9071
+    schemaRegistry:
+      enabled: false
+      tls:
+        enabled: false
+        authentication:
+          type: ""
+      url: http://schemaregistry:8081
+
+## Control Center (C3) Resource configuration
+##
+controlcenter:
+  name: controlcenter
+  license: ""
+  ##
+  ## C3 dependencies
+  ##
+  dependencies:
+    c3KafkaCluster:
+      brokerCount: 1
+      bootstrapEndpoint: kafka:9071
+      zookeeper:
+        endpoint: zookeeper:2181
+    connectCluster:
+      enabled: true
+      url: http://connectors:8083
+    ksql:
+      enabled: true
+      url: http://ksql:9088
+    schemaRegistry:
+      enabled: true
+      url: http://schemaregistry:8081
+  ##
+  ## C3 External Access
+  ##
+  loadBalancer:
+    enabled: false
+    domain: ""
+  ##
+  ## TLS configuration
+  ##
+  tls:
+    enabled: false
+    authentication:
+      type: ""
+    fullchain: |-
+    privkey: |-
+    cacerts: |-
+  ##
+  ## C3 authentication
+  ##
+  auth:
+    basic:
+      enabled: true
+      ##
+      ## map with key as user and value as password and role
+      property:
+        admin: Developer1,Administrators
+        disallowed: no_access

--- a/infrastructure/terraform-gcp/main.tf
+++ b/infrastructure/terraform-gcp/main.tf
@@ -2,12 +2,13 @@ provider "google" {
   credentials = file("account.json")
   project = var.project
   region = var.region
-  zone = var.zone
+  zone = var.zone1
 }
 
 resource "google_container_cluster" "cluster" {
   name = "car-demo-cluster"
-  location = var.region
+  location = var.zone1
+  remove_default_node_pool = true
   initial_node_count = 1
   master_auth {
     username = ""
@@ -34,7 +35,7 @@ resource "google_container_cluster" "cluster" {
 
 resource "google_container_node_pool" "primary_preemptible_nodes" {
   name       = "car-demo-node-pool"
-  location   = var.region
+  location   = var.zone1
   cluster    = google_container_cluster.cluster.name
   node_count = var.node_count
 
@@ -63,11 +64,14 @@ resource "null_resource" "setup-cluster" {
     id = google_container_cluster.cluster.id
     reg = var.region
     prj = var.project
+    rep = var.replicas
+    zo1 = var.zone1
     // Re-run script on deployment script changes
     script = sha1(file("setup.sh"))
+    
   }
 
   provisioner "local-exec" {
-    command = "./setup.sh ${google_container_cluster.cluster.name} ${var.region} ${var.project}"
+    command = "./setup.sh ${google_container_cluster.cluster.name} ${var.region} ${var.project} ${var.replicas} ${var.zone1}"
   }
 }

--- a/infrastructure/terraform-gcp/setup.sh
+++ b/infrastructure/terraform-gcp/setup.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 
+CNAME=${1}
+REGION=${2}
+PROJECT=${3}
+REPLICAS=${4}
+ZONE1=${5}
+
 set -e
 
 echo "Provisioning K8s cluster..."
 
-gcloud container clusters get-credentials ${1} --zone ${2}
+gcloud container clusters get-credentials ${1} --zone ${5}
+# gcloud container clusters get-credentials car-demo-cluster --zone europe-west1
 
 # Context should be set automatically
 #kubectl use-context gke_${3}_${2}_${1}
@@ -29,3 +36,94 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-b
 
 echo "Kubernetes Dashboard token:"
 gcloud config config-helper --format=json | jq -r '.credential.access_token'
+
+echo "Download Confluent Operator"
+# check if Confluent Operator still exist
+DIR="conluent-operator/"
+if [ -d "$DIR" ]; then
+  # Take action if $DIR exists. #
+  echo "Operator is installed..."
+else
+  mkdir confluent-operator
+  cd confluent-operator/
+  wget https://platform-ops-bin.s3-us-west-1.amazonaws.com/operator/confluent-operator-20190912-v0.65.1.tar.gz
+  tar -xvf confluent-operator-20190912-v0.65.1.tar.gz
+  rm confluent-operator-20190912-v0.65.1.tar.gz
+  cp ../gcp.yaml helm/providers/
+  cd helm/
+fi
+
+#echo "Install Confluent Operator"
+#helm delete --purge operator
+helm install \
+-f ./providers/gcp.yaml \
+--name operator \
+--namespace operator \
+--set operator.enabled=true \
+./confluent-operator
+sleep 5
+kubectl get pods -n operator
+
+echo "Install Confluent Zookeeper"
+#helm delete --purge zookeeper
+helm install \
+-f ./providers/gcp.yaml \
+--name zookeeper \
+--namespace operator \
+--set zookeeper.enabled=true \
+./confluent-operator
+sleep 50
+kubectl get pods -n operator
+
+echo "Install Confluent Kafka"
+#helm delete --purge kafka
+helm install \
+-f ./providers/gcp.yaml \
+--name kafka \
+--namespace operator \
+--set kafka.enabled=true \
+./confluent-operator
+sleep 50
+kubectl get pods -n operator
+
+echo "Install Confluent Schema Registry"
+#helm delete --purge schemaregistry
+helm install \
+-f ./providers/gcp.yaml \
+--name schemaregistry \
+--namespace operator \
+--set schemaregistry.enabled=true \
+./confluent-operator
+Sleep 50
+kubectl get pods -n operator
+
+echo "Install Confluent KSQL"
+# helm delete --purge ksql
+helm install \
+-f ./providers/gcp.yaml \
+--name ksql \
+--namespace operator \
+--set ksql.enabled=true \
+./confluent-operator
+Sleep 50
+kubectl get pods -n operator
+
+echo "Install Confluent Control Center"
+# helm delete --purge controlcenter
+helm install \
+-f ./providers/gcp.yaml \
+--name controlcenter \
+--namespace operator \
+--set controlcenter.enabled=true \
+./confluent-operator
+Sleep 50
+kubectl get pods -n operator
+
+echo "Create LB for Control Center"
+helm upgrade -f ./providers/gcp.yaml \
+ --set controlcenter.enabled=true \
+ --set controlcenter.loadBalancer.enabled=true \
+ --set controlcenter.loadBalancer.domain=axvy.aa.de controlcenter \
+ ./confluent-operator
+Sleep 50
+kubectl get services -n operator

--- a/infrastructure/terraform-gcp/variables.tf
+++ b/infrastructure/terraform-gcp/variables.tf
@@ -1,18 +1,24 @@
 variable "node_count" {
-  default = 3
+  default = 10
 }
 
 variable "region" {
   default = "europe-west1"
 }
 
-variable "zone" {
-  default = "europe-west1-c"
+variable "zone1" {
+  default = "europe-west1-b"
 }
+
 
 variable "preemptible_nodes" {
   default = "true"
 }
+
+variable "replicas" {
+  default = "1"
+}
+
 
 variable project {
   type = "string"


### PR DESCRIPTION
Hallo Kai,

also ich kurz ein Updates in den Readme gemacht und unter terraform-gcp den Confluent Operator eingebaut. Im wesentliche habe ich folgende Änderungen gemacht:
Nodes auf 10 erhöht
Zugriff direkt auf die Zone, so dass wir nur in der Zone erstellen und in alle drei Zonen der Region
Setup.sh angepasst, so dass der Confluent operator installiert wird und Confluent Platform in GKE installiert.
Ich habe ein gcp.yaml beigelegt, das ich nehme und in dem installieren gcp.yaml from downloaded Operator ersetze.
Verbesserungsvorschläge;
- Default Pool für den Cluster nutzen, dann geht Aufbau schneller.
   Der Cluster wird sowieso erstmal mit dem Default Node Pool aufgebaut. Wir legen einen neuen an 
   und dann muss der Cluster erstmal einen Upgrade machen, das ist blöd.
- Die Machine-types sind etwas hoch. Ich nutze --machine-type=n1-standard-2 hat auch gereicht
- Das replacement von gcp.yaml finde ich nicht gut, vielleicht hast Du eine andere Idee.