### PR TITLE
make initial setup fail more easily, add basic api availability check

### DIFF
--- a/infrastructure/confluent/01_installConfluentPlatform.sh
+++ b/infrastructure/confluent/01_installConfluentPlatform.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Check if cluster is running"
-gcloud container clusters list
+until kubectl cluster-info >/dev/null 2>&1; do
+    echo "kubeapi not available yet..."
+    sleep 3
+done
 
 echo "Deploying prometheus..."
 helm upgrade --namespace monitoring --install prom --version 6.8.1 stable/prometheus-operator --wait || true

--- a/infrastructure/terraform-gcp/00_setup_GKE.sh
+++ b/infrastructure/terraform-gcp/00_setup_GKE.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CNAME=${1}
 REGION=${2}
 PROJECT=${3}
@@ -12,6 +14,10 @@ gcloud container clusters get-credentials ${CNAME} --region ${REGION}
 
 # _idempotent_ setup
 
+until kubectl cluster-info >/dev/null 2>&1; do
+    echo "kubeapi not available yet..."
+    sleep 3
+done
 # Make tiller a cluster-admin so it can do whatever it wants
 kubectl apply -f tiller-rbac.yaml
 


### PR DESCRIPTION
this is just to be safe in case the kube apiserver is not available yet after deploying (it should _always_ be by default)